### PR TITLE
Add a deployment button for Netlify

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ Run the npm script 'build' to update `style.css` and `index.js` in the `public` 
 ```
 npm run build
 ```
+
+###Deploy Now
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/Jon-Biz/simple-static-react-aframe)
+

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = "public"


### PR DESCRIPTION
Just found this repo and it's pretty cool. I also noticed that this easily deploys to a CDN without the need for a server. Netlify is a host for progressive web apps and available for free as well.

I added a netlify.toml to save the build command and a deploy button so any user can click deploy to clone a version to their GitHub and see their changes live in production. 

Try it out:
[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/bdougie/simple-static-react-aframe)